### PR TITLE
feat: enhance admin product form with category management

### DIFF
--- a/hooks/supabase/categories.supabase.ts
+++ b/hooks/supabase/categories.supabase.ts
@@ -1,0 +1,23 @@
+import { supabase } from "@/utils/supabase/server"
+
+export interface CategoryRecord {
+  id: string
+  name: string
+  image?: string | null
+}
+
+export const listCategories = async (): Promise<CategoryRecord[]> => {
+  const { data, error } = await supabase.from("categories").select("id, name, image")
+  if (error) throw error
+  return data || []
+}
+
+export const createCategory = async (input: { name: string; image?: string }) => {
+  const { data, error } = await supabase
+    .from("categories")
+    .insert([{ name: input.name, image: input.image }])
+    .select()
+    .single()
+  if (error) throw error
+  return data as CategoryRecord
+}


### PR DESCRIPTION
## Summary
- add supabase hooks for listing and creating categories
- use select fields for product type and category in admin form
- allow creating new categories with name and image and show selected category image

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68a35176207c832e8c157ed590bdc53d