### PR TITLE
feat: fetch product from supabase

### DIFF
--- a/app/product/[id]/page.tsx
+++ b/app/product/[id]/page.tsx
@@ -1,13 +1,14 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import Image from "next/image"
 import { notFound } from "next/navigation"
 import SiteHeader from "@/components/site-header"
 import SiteFooter from "@/components/site-footer"
 import ProductConfigurator from "@/components/product-configurator"
 import ProductCard from "@/components/product-card"
-import { getProductById, products } from "@/lib/data"
+import { getProductById, listProducts } from "@/hooks/supabase/products.supabase"
+import { Products } from "@/interface/product.interface"
 import { CartProvider } from "@/components/cart"
 
 type PageProps = {
@@ -16,12 +17,32 @@ type PageProps = {
 
 export default function ProductPage({ params }: PageProps) {
   const id = params?.id ?? ""
-  const product = getProductById(id)
-  if (!product) return notFound()
-
-  const [selectedColor, setSelectedColor] = useState(product.product[0].color)
+  const [product, setProduct] = useState<Products | null>(null)
+  const [related, setRelated] = useState<Products[]>([])
+  const [selectedColor, setSelectedColor] = useState("")
   const [selectedImageIndex, setSelectedImageIndex] = useState(0) // Estado para imagen seleccionada
-  
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const p = await getProductById(id)
+        setProduct(p)
+        if (p) setSelectedColor(p.product[0]?.color || "")
+        const all = await listProducts()
+        setRelated(all.filter(pr => pr.id !== id).slice(0, 4))
+      } catch (err) {
+        console.error(err)
+      } finally {
+        setLoading(false)
+      }
+    }
+    if (id) load()
+  }, [id])
+
+  if (!loading && !product) return notFound()
+  if (!product) return null
+
   const selectedVariant = product.product.find(v => v.color === selectedColor) ?? product.product[0]
 
   return (
@@ -84,12 +105,9 @@ export default function ProductPage({ params }: PageProps) {
             <div className="mt-6 border-t pt-8">
               <h3 className="text-lg tracking-tight mb-6">También te puede gustar</h3>
               <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
-                {products
-                  .filter((p) => p.id !== product.id)
-                  .slice(0, 4)
-                  .map((p) => (
-                    <ProductCard key={p.id} product={p} />
-                  ))}
+                {related.map((p) => (
+                  <ProductCard key={p.id} product={p} />
+                ))}
               </div>
             </div>
           </div>

--- a/hooks/supabase/products.supabase.ts
+++ b/hooks/supabase/products.supabase.ts
@@ -27,6 +27,34 @@ export const listProducts = async (): Promise<any[]> => {
   )
 }
 
+export const getProductById = async (id: string): Promise<Products | null> => {
+  const { data, error } = await supabase
+    .from("products")
+    .select(
+      "id, title, description, type, material, price, discount_percentage, category:categories(name,image), product_variants(color,sizes,images)"
+    )
+    .eq("id", id)
+    .single()
+  if (error) throw error
+  if (!data) return null
+  return {
+    id: data.id,
+    title: data.title,
+    description: data.description,
+    type: data.type,
+    material: data.material,
+    price: data.price,
+    discountPercentage: data.discount_percentage,
+    category: { name: data.category?.name, image: data.category?.image },
+    product: (data.product_variants || []).map((v: any) => ({
+      color: v.color,
+      size: v.sizes || [],
+      images: v.images || [],
+      tags: ["men", "women", "kids"],
+    })),
+  }
+}
+
 export const createProduct = async (input: Products) => {
   const { data: category, error: catError } = await supabase
     .from("categories")


### PR DESCRIPTION
## Summary
- add Supabase helper to retrieve product details by id
- load product and related items from Supabase in `/product/[id]`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: interactive setup prompt)


------
https://chatgpt.com/codex/tasks/task_b_68a37822b628832e9276ab9980e8e5b3