### PR TITLE
feat: add product tags for category filtering

### DIFF
--- a/hooks/supabase/categories.supabase.ts
+++ b/hooks/supabase/categories.supabase.ts
@@ -42,7 +42,7 @@ export const getProductsByCategoryName = async (
   const { data, error, count } = await supabase
     .from("products")
     .select(
-      "id, title, description, type, material, price, discount_percentage, category:categories(name,image), product_variants(color,sizes,images)",
+      "id, title, description, type, material, price, discount_percentage, category:categories(name,image), product_variants(color,sizes,images,tags)",
       { count: "exact" }
     )
     .eq("category_id", categoryData.id)
@@ -65,7 +65,7 @@ export const getProductsByCategoryName = async (
         color: v.color,
         size: v.sizes || [],
         images: v.images || [],
-        tags: ["men", "women", "kids"],
+        tags: v.tags || [],
       })),
     })) || [];
 

--- a/hooks/supabase/products.supabase.ts
+++ b/hooks/supabase/products.supabase.ts
@@ -5,7 +5,7 @@ export const listProducts = async (): Promise<any[]> => {
   const { data, error } = await supabase
     .from("products")
     .select(
-      "id, title, description, type, material, price, discount_percentage, category:categories(name,image), product_variants(color,sizes,images)"
+      "id, title, description, type, material, price, discount_percentage, category:categories(name,image), product_variants(color,sizes,images,tags)"
     )
   if (error) throw error
   return (
@@ -22,6 +22,7 @@ export const listProducts = async (): Promise<any[]> => {
         color: v.color,
         size: v.sizes || [],
         images: v.images || [],
+        tags: v.tags || [],
       })),
     })) || []
   )
@@ -31,7 +32,7 @@ export const getProductById = async (id: string): Promise<Products | null> => {
   const { data, error } = await supabase
     .from("products")
     .select(
-      "id, title, description, type, material, price, discount_percentage, category:categories(name,image), product_variants(color,sizes,images)"
+      "id, title, description, type, material, price, discount_percentage, category:categories(name,image), product_variants(color,sizes,images,tags)"
     )
     .eq("id", id)
     .single()
@@ -50,7 +51,7 @@ export const getProductById = async (id: string): Promise<Products | null> => {
       color: v.color,
       size: v.sizes || [],
       images: v.images || [],
-      tags: ["men", "women", "kids"],
+      tags: v.tags || [],
     })),
   }
 }
@@ -83,6 +84,7 @@ export const createProduct = async (input: Products) => {
     color: v.color,
     sizes: v.size,
     images: v.images,
+    tags: v.tags,
   }))
   const { error: variantError } = await supabase.from("product_variants").insert(variants)
   if (variantError) throw variantError
@@ -121,6 +123,7 @@ export const updateProduct = async (id: string, input: Partial<Products>) => {
       color: v.color,
       sizes: v.size,
       images: v.images,
+      tags: v.tags,
     }))
     const { error: variantError } = await supabase.from("product_variants").insert(variants)
     if (variantError) throw variantError

--- a/products.sql
+++ b/products.sql
@@ -21,13 +21,14 @@ CREATE TABLE public.products (
   updated_at timestamptz DEFAULT now()
 );
 
--- Variants for colors, sizes and images
+-- Variants for colors, sizes, images and tags
 CREATE TABLE public.product_variants (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   product_id uuid REFERENCES public.products(id) ON DELETE CASCADE,
   color text,
   sizes text[],
-  images text[]
+  images text[],
+  tags text[]
 );
 
 -- Enable RLS


### PR DESCRIPTION
## Summary
- add tag array to product variants schema
- persist variant tags when creating and updating products
- load tags from Supabase for category filtering

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires ESLint configuration)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a610b403ec832eb4b08c4030149503