### PR TITLE
feat: secure auth and supabase wishlist

### DIFF
--- a/hooks/supabase/wishlist.supabase.ts
+++ b/hooks/supabase/wishlist.supabase.ts
@@ -1,0 +1,42 @@
+import { supabase } from "@/utils/supabase/server"
+
+export async function fetchWishlist(userId: string): Promise<string[]> {
+  const { data, error } = await supabase
+    .from("wishlist")
+    .select("slug")
+    .eq("user_id", userId)
+
+  if (error) throw error
+  return data?.map((r: any) => r.slug) || []
+}
+
+export async function toggleWishlistItem(userId: string, slug: string) {
+  const { data, error } = await supabase
+    .from("wishlist")
+    .select("id")
+    .eq("user_id", userId)
+    .eq("slug", slug)
+
+  if (error) throw error
+
+  if (data && data.length > 0) {
+    const { error: delError } = await supabase
+      .from("wishlist")
+      .delete()
+      .eq("id", data[0].id)
+    if (delError) throw delError
+  } else {
+    const { error: insError } = await supabase
+      .from("wishlist")
+      .insert({ user_id: userId, slug })
+    if (insError) throw insError
+  }
+}
+
+export async function clearWishlist(userId: string) {
+  const { error } = await supabase
+    .from("wishlist")
+    .delete()
+    .eq("user_id", userId)
+  if (error) throw error
+}

--- a/store/authStore.ts
+++ b/store/authStore.ts
@@ -3,7 +3,9 @@ import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 
 interface User {
+  id: string;
   name: string;
+  lastname: string;
   email: string;
   tel: string;
 }

--- a/wishlist.sql
+++ b/wishlist.sql
@@ -1,0 +1,11 @@
+-- Wishlist table
+CREATE TABLE public.wishlist (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
+  slug text NOT NULL
+);
+
+ALTER TABLE public.wishlist ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users manage own wishlist" ON public.wishlist
+FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- strengthen login and registration with validation and Supabase session integration
- track user identifiers in auth store
- back wishlist with Supabase and provide SQL for deployment

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_b_68a73ca27978832ea6ef3d1769c798c6