### PR TITLE
feat: add wishlist toggles

### DIFF
--- a/components/product-card.tsx
+++ b/components/product-card.tsx
@@ -2,10 +2,11 @@
 
 import Image from "next/image"
 import Link from "next/link"
-import { ShoppingBag } from 'lucide-react'
+import { ShoppingBag, Heart } from 'lucide-react'
 import { formatCurrency } from "@/lib/format"
 import { Button } from "@/components/ui/button"
 import { useCart } from "@/components/cart"
+import { useWishlist } from "@/components/wishlist"
 import { Products } from "@/interface/product.interface"
 
 type Props = {
@@ -36,7 +37,9 @@ const PLACEHOLDER_PRODUCT: Products = {
 
 export default function ProductCard({ product = PLACEHOLDER_PRODUCT, showQuickBuy = true }: Props) {
   const { addItem, setOpen, beginCheckout } = useCart()
+  const { isSaved, toggle } = useWishlist()
   const primaryImage = product.product[0].images[0] || "/placeholder.svg"
+  const saved = isSaved(product.id)
 
   const handleAdd = (e: React.MouseEvent) => {
     e.preventDefault()
@@ -59,6 +62,12 @@ export default function ProductCard({ product = PLACEHOLDER_PRODUCT, showQuickBu
     beginCheckout()
   }
 
+  const handleWishlist = (e: React.MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    toggle(product.id)
+  }
+
   return (
     <article className="group grid gap-3">
       <Link href={`/product/${product.id}`} className="relative block">
@@ -71,6 +80,16 @@ export default function ProductCard({ product = PLACEHOLDER_PRODUCT, showQuickBu
             className="object-cover transition-transform duration-700 group-hover:scale-[1.03]"
             priority={false}
           />
+
+          <Button
+            variant="secondary"
+            size="icon"
+            aria-label={saved ? "Quitar de la wishlist" : "Agregar a la wishlist"}
+            className="absolute left-2 top-2 h-9 w-9 opacity-95 hover:opacity-100 transition-opacity"
+            onClick={handleWishlist}
+          >
+            <Heart className="h-4 w-4" fill={saved ? "currentColor" : "none"} />
+          </Button>
 
           {showQuickBuy && (
             <Button

--- a/components/product-configurator.tsx
+++ b/components/product-configurator.tsx
@@ -7,6 +7,8 @@ import { Label } from "@/components/ui/label"
 import { Badge } from "@/components/ui/badge"
 import { formatCurrency } from "@/lib/format"
 import { useCart } from "./cart"
+import { useWishlist } from "@/components/wishlist"
+import { Heart } from 'lucide-react'
 import { Products, ProductTag } from "@/interface/product.interface"
 
 type Props = {
@@ -38,6 +40,7 @@ export default function ProductConfigurator({
   const [selectedImageIndex, setSelectedImageIndex] = useState(0) // Estado para imagen seleccionada
 
   const { addItem } = useCart()
+  const { isSaved, toggle } = useWishlist()
 
   const tags = useMemo(() => {
     const all = p.product.flatMap((v) => v.tags || [])
@@ -80,6 +83,8 @@ export default function ProductConfigurator({
       onImageSelect(index) // Notificar al componente padre si es necesario
     }
   }
+
+  const saved = isSaved(p.id)
 
   return (
     <div className="grid gap-6">
@@ -166,10 +171,19 @@ export default function ProductConfigurator({
           </div>
         )}
 
-        {/* Botón agregar */}
+        {/* Botones de acción */}
         <div className="grid gap-2">
           <Button className="h-11 rounded-none" onClick={handleAdd}>
             Agregar al carrito
+          </Button>
+          <Button
+            variant="outline"
+            className="h-11 rounded-none flex items-center gap-2"
+            onClick={() => toggle(p.id)}
+            aria-label={saved ? "Quitar de la wishlist" : "Agregar a la wishlist"}
+          >
+            <Heart className="h-4 w-4" fill={saved ? "currentColor" : "none"} />
+            {saved ? "Quitar de la wishlist" : "Agregar a la wishlist"}
           </Button>
           <p className="text-xs text-muted-foreground">
             Envío gratis a partir de {formatCurrency(120)}.


### PR DESCRIPTION
## Summary
- add wishlist button to product cards
- allow configuring wishlist from product page

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_b_68a745d6896c832eac2a88fd167dc3a1