### PR TITLE
Fix wishlist persistence and rendering

### DIFF
--- a/app/wishlist/page.tsx
+++ b/app/wishlist/page.tsx
@@ -10,7 +10,7 @@ import { listAllProducts } from "@/lib/admin-store"
 export default function WishlistPage() {
   const { slugs, clear } = useWishlist()
   // Nota: listAllProducts es cliente, mezcla base + admin (visibilidad se gestiona aparte)
-  const products = listAllProducts().filter((p) => slugs.includes(p.slug))
+  const products = listAllProducts().filter((p) => slugs.includes(p.id))
 
   return (
     <CartProvider>

--- a/components/wishlist.tsx
+++ b/components/wishlist.tsx
@@ -27,13 +27,17 @@ export function useWishlist() {
   const [slugs, setSlugs] = useState<string[]>([])
 
   useEffect(() => {
+    // Always seed state from localStorage so saved hearts render immediately
+    setSlugs(read())
+
     const userId = user?.id
-    if (!userId) {
-      setSlugs(read())
-      return
-    }
+    if (!userId) return
+
     fetchWishlist()
-      .then(setSlugs)
+      .then((list) => {
+        setSlugs(list)
+        write(list) // keep localStorage in sync
+      })
       .catch(() => setSlugs([]))
   }, [user?.id]) // depend on the id only
 
@@ -53,6 +57,7 @@ export function useWishlist() {
       await toggleWishlistItem(slug)
       const updated = await fetchWishlist()
       setSlugs(updated)
+      write(updated) // persist for faster client loads
     },
     [user?.id]
   )
@@ -66,6 +71,7 @@ export function useWishlist() {
     }
     await clearWishlistApi()
     setSlugs([])
+    write([])
   }, [user?.id])
 
   return useMemo(() => ({ slugs, isSaved, toggle, clear }), [slugs, isSaved, toggle, clear])


### PR DESCRIPTION
## Summary
- sync wishlist state with local storage and server so hearts stay filled
- filter wishlist page by product id to show saved items

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_b_68a7554aaa94832e9f825a21972df972