### PR TITLE
Persist user id in localStorage for wishlist usage

### DIFF
--- a/store/authStore.ts
+++ b/store/authStore.ts
@@ -28,20 +28,26 @@ export const useAuthStore = create<AuthState>()(
       isAuthenticated: false,
       isLoading: false,
       login: (userData: User, authToken: string) => {
-        set({ 
-          user: userData, 
+        set({
+          user: userData,
           token: authToken,
           isAuthenticated: true,
-          isLoading: false 
+          isLoading: false
         });
+        try {
+          localStorage.setItem('user_id', userData.id)
+        } catch {}
       },
       logout: () => {
-        set({ 
-          user: null, 
+        set({
+          user: null,
           token: null,
           isAuthenticated: false,
-          isLoading: false 
+          isLoading: false
         });
+        try {
+          localStorage.removeItem('user_id')
+        } catch {}
         location.reload()
       },
       setLoading: (loading: boolean) => set({ isLoading: loading })


### PR DESCRIPTION
## Summary
- save authenticated user's id to localStorage on login
- clear saved id on logout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68a7627acd38832e80dce70ba2777e23