### PR TITLE
Sync wishlist on login and require auth for favorites

### DIFF
--- a/components/product-card.tsx
+++ b/components/product-card.tsx
@@ -66,7 +66,6 @@ export default function ProductCard({ product = PLACEHOLDER_PRODUCT, showQuickBu
   const handleWishlist = (e: React.MouseEvent) => {
     e.preventDefault()
     e.stopPropagation()
-    console.log(product.id)
     toggle(product.id)
   }
 

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -11,6 +11,7 @@ import MobileNav from "./mobile-nav"
 import { useAuth } from "@/components/auth"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, DropdownMenuLabel, DropdownMenuSeparator } from "@/components/ui/dropdown-menu"
 import { useAuthStore } from "@/store/authStore"
+import { useWishlist } from "@/components/wishlist"
 
 export default function SiteHeader() {
   const { count, setOpen } = useCart()
@@ -19,6 +20,7 @@ export default function SiteHeader() {
   const user = useAuthStore((state) => state.user)
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
   const logout = useAuthStore((state) => state.logout)
+  useWishlist()
 
   return (
     <header className="sticky top-0 z-40 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 border-b">

--- a/components/wishlist.tsx
+++ b/components/wishlist.tsx
@@ -7,6 +7,7 @@ import {
   toggleWishlistItem,
   clearWishlist as clearWishlistApi,
 } from "@/hooks/supabase/wishlist.supabase"
+import { toast } from "@/components/ui/use-toast"
 
 const KEY = "inkspire_wishlist"
 
@@ -46,18 +47,15 @@ export function useWishlist() {
   const toggle = useCallback(
     async (slug: string) => {
       const userId = user?.id
-      console.log('user id', user)
       if (!userId) {
-        setSlugs((prev) => {
-          const next = prev.includes(slug) ? prev.filter((s) => s !== slug) : [slug, ...prev]
-          write(next)
-          return next
+        toast({
+          title: "Inicia sesión",
+          description: "Debes iniciar sesión para guardar favoritos",
         })
         return
       }
       await toggleWishlistItem(slug)
       const updated = await fetchWishlist()
-      console.log(updated)
       setSlugs(updated)
       write(updated) // persist for faster client loads
     },


### PR DESCRIPTION
## Summary
- sync wishlist from Supabase on header mount for logged-in users
- block wishlist toggles without authentication and show toast message
- clean up wishlist handler in product card

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompts for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_b_68a7f6140458832e92759750b69057a5