### PR TITLE
Fetch wishlist products from Supabase

### DIFF
--- a/app/wishlist/page.tsx
+++ b/app/wishlist/page.tsx
@@ -1,16 +1,34 @@
 "use client"
 
+import { useEffect, useState } from "react"
 import SiteHeader from "@/components/site-header"
 import SiteFooter from "@/components/site-footer"
 import ProductCard from "@/components/product-card"
 import { CartProvider } from "@/components/cart"
 import { useWishlist } from "@/components/wishlist"
-import { listAllProducts } from "@/lib/admin-store"
+import { getProductsByIds } from "@/hooks/supabase/products.supabase"
+import { Products } from "@/interface/product.interface"
 
 export default function WishlistPage() {
   const { slugs, clear } = useWishlist()
-  // Nota: listAllProducts es cliente, mezcla base + admin (visibilidad se gestiona aparte)
-  const products = listAllProducts().filter((p) => slugs.includes(p.id))
+  const [products, setProducts] = useState<Products[]>([])
+
+  useEffect(() => {
+    const load = async () => {
+      if (slugs.length === 0) {
+        setProducts([])
+        return
+      }
+      try {
+        const fetched = await getProductsByIds(slugs)
+        setProducts(fetched)
+      } catch (err) {
+        console.error(err)
+        setProducts([])
+      }
+    }
+    load()
+  }, [slugs])
 
   return (
     <CartProvider>

--- a/hooks/supabase/products.supabase.ts
+++ b/hooks/supabase/products.supabase.ts
@@ -122,6 +122,47 @@ export const listProducts = async (): Promise<Products[]> => {
   }));
 }
 
+export const getProductsByIds = async (ids: string[]): Promise<Products[]> => {
+  if (ids.length === 0) return []
+
+  const { data, error } = await supabase
+    .from("products")
+    .select(`
+      id,
+      title,
+      description,
+      type,
+      material,
+      price,
+      discount_percentage,
+      category:categories(name,image),
+      product_variants(color,sizes,images,tags)
+    `)
+    .in("id", ids)
+
+  if (error) throw error
+
+  return (data || []).map((p: any) => ({
+    id: p.id,
+    title: p.title,
+    description: p.description,
+    type: p.type,
+    material: p.material,
+    price: p.price,
+    discountPercentage: p.discount_percentage,
+    category: {
+      name: p.category?.name,
+      image: p.category?.image
+    },
+    product: (p.product_variants || []).map((v: any) => ({
+      color: v.color,
+      size: v.sizes || [],
+      images: v.images || [],
+      tags: v.tags || [],
+    })),
+  }))
+}
+
 // Las otras funciones (getProductById, createProduct, updateProduct, deleteProduct) se mantienen igual
 export const getProductById = async (id: string): Promise<Products | null> => {
   const { data, error } = await supabase


### PR DESCRIPTION
## Summary
- query Supabase for multiple product IDs
- load wishlist items from Supabase instead of local admin data

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68a7fd227aec832ea8f858861dfdef62