### PR TITLE
feat: persist user role securely

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -2,24 +2,26 @@
 
 import { useEffect } from "react"
 import { usePathname, useRouter } from "next/navigation"
+import { useAuthStore } from "@/store/authStore"
 
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
   const router = useRouter()
   const pathname = usePathname()
+  const user = useAuthStore((s) => s.user)
 
   useEffect(() => {
-    const authed = typeof window !== "undefined" && localStorage.getItem("admin_authed") === "1"
+    const isAdmin = user?.role === "admin"
 
-    // If visiting /admin (or any subroute except /admin/signin) and NOT authed -> redirect to signin
-    if (!authed && pathname !== "/admin/signin") {
+    // If visiting /admin (or subroutes) and not admin -> redirect to signin
+    if (!isAdmin && pathname !== "/admin/signin") {
       router.replace("/admin/signin")
       return
     }
-    // If already authed and on /admin/signin, go to /admin
-    if (authed && pathname === "/admin/signin") {
+    // If already admin and on /admin/signin, go to /admin
+    if (isAdmin && pathname === "/admin/signin") {
       router.replace("/admin")
     }
-  }, [pathname, router])
+  }, [pathname, router, user])
 
   return <>{children}</>
 }

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -31,10 +31,15 @@ import {
 import { Order, listAllOrders, updateOrderStatus } from "@/hooks/supabase/orders.supabase"
 import { CartProvider } from "@/components/cart"
 import { Products, ProductTag } from "@/interface/product.interface"
+import { useAuthStore } from "@/store/authStore"
+import { useRouter } from "next/navigation"
 
 const TAG_OPTIONS: ProductTag[] = ["women", "men", "kids"]
 
 export default function AdminPage() {
+  const logout = useAuthStore((s) => s.logout)
+  const router = useRouter()
+
   return (
     <CartProvider>
       <div className="flex min-h-[100dvh] flex-col bg-white">
@@ -50,9 +55,8 @@ export default function AdminPage() {
             <form
               onSubmit={(e) => {
                 e.preventDefault()
-                localStorage.removeItem("admin_authed")
-                localStorage.removeItem("admin_email")
-                window.location.href = "/admin/signin"
+                logout()
+                router.replace("/admin/signin")
               }}
             >
               <Button type="submit" variant="outline" className="rounded-none">

--- a/app/admin/signin/page.tsx
+++ b/app/admin/signin/page.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { useAuthStore, type User as AuthStoreUser } from "@/store/authStore"
 
 export default function AdminSignInPage() {
   const router = useRouter()
@@ -13,13 +14,15 @@ export default function AdminSignInPage() {
   const [password, setPassword] = useState("")
   const [error, setError] = useState<string | null>(null)
   const [pending, setPending] = useState(false)
+  const loginStore = useAuthStore((s) => s.login)
+  const user = useAuthStore((s) => s.user)
 
   useEffect(() => {
-    // If already authed, layout will redirect; this is just a safety check.
-    if (localStorage.getItem("admin_authed") === "1") {
+    // If already admin, redirect
+    if (user?.role === "admin") {
       router.replace("/admin")
     }
-  }, [router])
+  }, [router, user])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -33,8 +36,15 @@ export default function AdminSignInPage() {
     // Very simple client-side check
     setTimeout(() => {
       if ((email || "").toLowerCase() === DEMO_EMAIL && password === DEMO_PASS) {
-        localStorage.setItem("admin_authed", "1")
-        localStorage.setItem("admin_email", email)
+        const authUser: AuthStoreUser = {
+          id: "demo-admin",
+          name: "Admin",
+          lastname: "",
+          email,
+          tel: "",
+          role: "admin",
+        }
+        loginStore(authUser, "")
         router.replace("/admin")
       } else {
         setError("Credenciales inválidas. Prueba admin@inkspire.local / admin123")

--- a/components/auth.tsx
+++ b/components/auth.tsx
@@ -6,7 +6,7 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
 import { Label } from "@/components/ui/label"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
-import { useAuthStore } from "@/store/authStore"
+import { useAuthStore, type User as AuthStoreUser } from "@/store/authStore"
 import signUp from "@/hooks/supabase/signup.supabase"
 import { signIn } from "@/hooks/supabase/signin.supabase"
 import { z } from "zod"
@@ -242,12 +242,13 @@ function AuthModal({
         throw result.error
       }
 
-      const authUser = {
+      const authUser: AuthStoreUser = {
         id: result.user.id,
         name: result.user.profile?.name || "",
         lastname: result.user.profile?.lastname || "",
         tel: result.user.profile?.tel || "",
         email: result.user.email || "",
+        role: (result.user as any)?.user_metadata?.role || "user",
       }
 
       useAuthStore.getState().login(authUser, result.session?.access_token || "")

--- a/store/authStore.ts
+++ b/store/authStore.ts
@@ -1,13 +1,14 @@
 // store.ts
 import { create } from 'zustand';
-import { persist, createJSONStorage } from 'zustand/middleware';
+import { persist } from 'zustand/middleware';
 
-interface User {
+export interface User {
   id: string;
   name: string;
   lastname: string;
   email: string;
   tel: string;
+  role: string;
 }
 
 interface AuthState {
@@ -54,7 +55,18 @@ export const useAuthStore = create<AuthState>()(
     }),
     {
       name: 'auth-storage',
-      storage: createJSONStorage(() => localStorage),
+      storage: {
+        getItem: (name) => {
+          const value = localStorage.getItem(name)
+          return value ? atob(value) : null
+        },
+        setItem: (name, value) => {
+          localStorage.setItem(name, btoa(value))
+        },
+        removeItem: (name) => localStorage.removeItem(name),
+      },
+      serialize: (state) => JSON.stringify(state),
+      deserialize: (str) => JSON.parse(str),
     }
   )
 );


### PR DESCRIPTION
## Summary
- store user role in zustand with base64 persistence to hide readable data
- restrict admin routes to users with the `admin` role and integrate auth store login/logout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_b_68a88e6005e4832ebd410d18c13fec5a