### PR TITLE
Fix Supabase role handling and clean local storage

### DIFF
--- a/components/auth.tsx
+++ b/components/auth.tsx
@@ -37,7 +37,6 @@ type AuthContextType = {
 const AuthContext = createContext<AuthContextType | undefined>(undefined)
 
 const KEY_CURRENT_USER = "inkspire_current_user"
-const KEY_USERS = "inkspire_users"
 const KEY_USER_ORDERS = "inkspire_user_orders"
 
 const loginSchema = z.object({
@@ -94,13 +93,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, [])
 
   const login = useCallback(async (email: string, _password: string) => {
-    const users = getJSON<Record<string, User>>(KEY_USERS, {})
-    if (!users[email]) {
-      users[email] = { email }
-      setJSON(KEY_USERS, users)
-    }
-    setJSON(KEY_CURRENT_USER, users[email])
-    setUser(users[email])
+    const current: User = { email }
+    setJSON(KEY_CURRENT_USER, current)
+    setUser(current)
     setOpen(false)
     resolverRef.current?.()
     resolverRef.current = null
@@ -117,17 +112,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     if (data.password !== data.confirmPassword) {
       throw new Error("Las contraseñas no coinciden")
     }
-
-    const users = getJSON<Record<string, User>>(KEY_USERS, {})
-    users[data.email] = {
+    const newUser: User = {
       email: data.email,
       name: data.name,
       lastName: data.lastName,
-      phone: data.phone
+      phone: data.phone,
     }
-    setJSON(KEY_USERS, users)
-    setJSON(KEY_CURRENT_USER, users[data.email])
-    setUser(users[data.email])
+    setJSON(KEY_CURRENT_USER, newUser)
+    setUser(newUser)
     setOpen(false)
     resolverRef.current?.()
     resolverRef.current = null
@@ -248,7 +240,7 @@ function AuthModal({
         lastname: result.user.profile?.lastname || "",
         tel: result.user.profile?.tel || "",
         email: result.user.email || "",
-        role: (result.user as any)?.user_metadata?.role || "user",
+        role: result.user.profile?.role || "user",
       }
 
       useAuthStore.getState().login(authUser, result.session?.access_token || "")

--- a/hooks/supabase/signin.supabase.ts
+++ b/hooks/supabase/signin.supabase.ts
@@ -24,7 +24,7 @@ export async function signIn(signInData: signInProps) {
     // Paso 3: Obtener perfil extendido
     const { data: profile, error: profileError } = await supabase
       .from("users")
-      .select("name, lastname, tel, active")
+      .select("name, lastname, tel, active, role")
       .eq("id", authData.user.id)
       .single();
 

--- a/store/authStore.ts
+++ b/store/authStore.ts
@@ -34,9 +34,6 @@ export const useAuthStore = create<AuthState>()(
           isAuthenticated: true,
           isLoading: false
         });
-        try {
-          localStorage.setItem('user_id', userData.id);
-        } catch {}
       },
       logout: () => {
         set({
@@ -46,7 +43,6 @@ export const useAuthStore = create<AuthState>()(
           isLoading: false
         });
         try {
-          localStorage.removeItem('user_id');
           localStorage.removeItem('auth-storage');
           localStorage.removeItem('inkspire_wishlist');
         } catch {}


### PR DESCRIPTION
## Summary
- read user role from Supabase profile during sign-in
- stop persisting user lists and user ID in local storage

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompts for ESLint configuration)

------
https://chatgpt.com/codex/tasks/task_b_68a8972adbb8832ea9a70a347472afbe