### PR TITLE
feat: validate user signup and rollback on profile error

### DIFF
--- a/components/auth.tsx
+++ b/components/auth.tsx
@@ -281,7 +281,7 @@ function AuthModal({
         throw new Error(parsed.error.issues[0].message)
       }
 
-      const { data, error }: any = await signUp({
+      const { data, error } = await signUp({
         name: parsed.data.name,
         lastname: parsed.data.lastName,
         tel: parsed.data.phone,
@@ -290,7 +290,7 @@ function AuthModal({
       })
 
       if (error) {
-        throw error
+        throw new Error(error)
       }
 
       console.log("Usuario registrado:", data)

--- a/utils/supabase/admin.ts
+++ b/utils/supabase/admin.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || ""
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY || ""
+
+export const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey)


### PR DESCRIPTION
## Summary
- add Supabase admin client to remove auth users on failure
- improve signup hook to return structured result and rollback profile insert
- adjust registration component to handle signup errors

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (warn: requires interactive setup)


------
https://chatgpt.com/codex/tasks/task_b_68a8b0369d84832e9c1eda7c49d48d12