### PR TITLE
feat: fetch products by type in categories

### DIFF
--- a/app/categories/[category]/page.tsx
+++ b/app/categories/[category]/page.tsx
@@ -14,7 +14,7 @@ import { Input } from "@/components/ui/input"
 import PaginatedGrid from "@/components/paginated-grid"
 import { getVisibilityMap } from "@/lib/admin-store"
 import { getProductsByCategoryName } from "@/hooks/supabase/categories.supabase"
-import { listProducts } from "@/hooks/supabase/products.supabase"
+import { getProductsByType } from "@/hooks/supabase/products.supabase"
 import { Products } from "@/interface/product.interface"
 
 interface CategoryDetailPageProps {
@@ -37,11 +37,21 @@ export default function CategoryDetailPage({ params }: CategoryDetailPageProps) 
   const [baseItemsRaw, setBaseItemsRaw] = useState<Products[]>([])
   const load = async () => {
     try {
-      if (paramCat === "tshirts") {
-        const all = await listProducts()
-        setBaseItemsRaw(all.filter(p => p.type === "t-shirt"))
+      const typeMap: Record<string, Products["type"]> = {
+        tshirt: "t-shirt",
+        hoodie: "hoodie",
+        polo: "polo",
+        croptop: "croptop",
+        oversized: "oversized",
+        "long-sleeve": "long-sleeve",
+      }
+
+      const productType = paramCat ? typeMap[paramCat.toLowerCase()] : undefined
+
+      if (productType) {
+        const products = await getProductsByType(productType)
+        setBaseItemsRaw(products)
       } else {
-        console.log(paramCat)
         const { products } = await getProductsByCategoryName(paramCat)
         if (products.length === 0) {
           // Manejar caso donde no hay productos

--- a/hooks/supabase/products.supabase.ts
+++ b/hooks/supabase/products.supabase.ts
@@ -124,6 +124,50 @@ export const getFilteredProducts = async (filters: {
   return products;
 }
 
+// Función para obtener productos por tipo
+export const getProductsByType = async (
+  type: Products["type"]
+): Promise<Products[]> => {
+  const { data, error } = await supabase
+    .from("products")
+    .select(
+      `
+      id,
+      title,
+      description,
+      type,
+      material,
+      price,
+      discount_percentage,
+      category:categories(name,image),
+      product_variants(color,sizes,images,tags)
+    `
+    )
+    .eq("type", type);
+
+  if (error) throw error;
+
+  return (data || []).map((p: any) => ({
+    id: p.id,
+    title: p.title,
+    description: p.description,
+    type: p.type,
+    material: p.material,
+    price: p.price,
+    discountPercentage: p.discount_percentage,
+    category: {
+      name: p.category?.name,
+      image: p.category?.image,
+    },
+    product: (p.product_variants || []).map((v: any) => ({
+      color: v.color,
+      size: v.sizes || [],
+      images: v.images || [],
+      tags: v.tags || [],
+    })),
+  }));
+};
+
 // Función original para listar productos (mantenida para compatibilidad)
 export const listProducts = async (): Promise<Products[]> => {
   const { data, error } = await supabase


### PR DESCRIPTION
## Summary
- add Supabase helper to query products by type
- load products by type from category routes

## Testing
- `npm test` (fails: Missing script: test)
- `npm run lint` (prompts for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_b_68a9e6735ca4832eb117495e34ec7d13