### PR TITLE
feat: save service form submissions in supabase

### DIFF
--- a/app/services/actions.ts
+++ b/app/services/actions.ts
@@ -1,19 +1,35 @@
 "use server"
 
-export async function requestDesign(formData: FormData) {
-  // Simulación de procesamiento
-  await new Promise((res) => setTimeout(res, 800))
+import { createServiceRequest, uploadServiceFiles } from "@/hooks/supabase/services.supabase"
 
+export async function requestDesign(formData: FormData) {
   const name = String(formData.get("name") ?? "")
   const email = String(formData.get("email") ?? "")
   const service = String(formData.get("service") ?? "")
   const message = String(formData.get("message") ?? "")
-  const budget = String(formData.get("budget") ?? "")
+  const budgetValue = formData.get("budget")
+  const budget = budgetValue ? Number(budgetValue) : undefined
 
-  // Retornar confirmación (en producción, aquí enviarías email o guardarías en DB)
+  const files = formData
+    .getAll("refs")
+    .filter((f): f is File => f instanceof File && f.size > 0)
+  let ref_urls: string[] = []
+  if (files.length) {
+    ref_urls = await uploadServiceFiles(files)
+  }
+
+  await createServiceRequest({
+    name,
+    email,
+    service,
+    budget,
+    message,
+    ref_urls,
+  })
+
   return {
     ok: true,
-    summary: `Solicitud recibida de ${name} (${email}) para ${service}. Presupuesto: ${budget}.`,
+    summary: `Solicitud recibida de ${name} (${email}) para ${service}. Presupuesto: ${budget ?? "N/A"}.`,
     message,
   }
 }

--- a/hooks/supabase/services.supabase.ts
+++ b/hooks/supabase/services.supabase.ts
@@ -1,0 +1,44 @@
+import { supabase } from "@/utils/supabase/server"
+
+const BUCKET = "isbucket"
+
+export interface ServiceRequestInput {
+  name: string
+  email: string
+  service: string
+  budget?: number
+  message?: string
+  ref_urls?: string[]
+}
+
+export async function uploadServiceFiles(files: File[]): Promise<string[]> {
+  const urls: string[] = []
+  for (const file of files) {
+    const ext = file.name.split(".").pop()
+    const fileName = `${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`
+    const { error } = await supabase.storage.from(BUCKET).upload(fileName, file)
+    if (error) throw error
+    const {
+      data: { publicUrl },
+    } = supabase.storage.from(BUCKET).getPublicUrl(fileName)
+    urls.push(publicUrl)
+  }
+  return urls
+}
+
+export async function createServiceRequest(input: ServiceRequestInput) {
+  const { data, error } = await supabase
+    .from("service_requests")
+    .insert({
+      name: input.name,
+      email: input.email,
+      service: input.service,
+      budget: input.budget,
+      message: input.message,
+      ref_urls: input.ref_urls,
+    })
+    .select()
+    .single()
+  if (error) throw error
+  return data
+}

--- a/services.sql
+++ b/services.sql
@@ -1,0 +1,19 @@
+-- Service requests table
+CREATE TABLE public.service_requests (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL,
+  email text NOT NULL,
+  service text NOT NULL,
+  budget numeric(10,2),
+  message text,
+  ref_urls text[],
+  created_at timestamptz DEFAULT now()
+);
+
+ALTER TABLE public.service_requests ENABLE ROW LEVEL SECURITY;
+
+-- Allow anonymous inserts
+CREATE POLICY "Allow anon insert" ON public.service_requests
+  FOR INSERT
+  TO anon
+  WITH CHECK (true);


### PR DESCRIPTION
## Summary
- add service_requests table and policies
- store service form submissions with file uploads

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: How would you like to configure ESLint?)

------
https://chatgpt.com/codex/tasks/task_b_68aa063cc634832ebf59bcd64c8d4961