### PR TITLE
feat: list service requests and fetch featured products from Supabase

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -29,6 +29,7 @@ import {
   listCategories,
 } from "@/hooks/supabase/categories.supabase"
 import { Order, listAllOrders, updateOrderStatus } from "@/hooks/supabase/orders.supabase"
+import { ServiceRequest, listServiceRequests } from "@/hooks/supabase/services.supabase"
 import { CartProvider } from "@/components/cart"
 import { Products, ProductTag } from "@/interface/product.interface"
 import { useAuthStore } from "@/store/authStore"
@@ -67,6 +68,7 @@ export default function AdminPage() {
               <TabsTrigger value="inventory" className="rounded-none">Inventario</TabsTrigger>
               <TabsTrigger value="new" className="rounded-none">Nuevo producto</TabsTrigger>
               <TabsTrigger value="orders" className="rounded-none">Órdenes</TabsTrigger>
+              <TabsTrigger value="services" className="rounded-none">Servicios</TabsTrigger>
             </TabsList>
 
             <TabsContent value="inventory" className="mt-6">
@@ -79,6 +81,10 @@ export default function AdminPage() {
 
             <TabsContent value="orders" className="mt-6">
               <OrdersTab />
+            </TabsContent>
+
+            <TabsContent value="services" className="mt-6">
+              <ServiceRequestsTab />
             </TabsContent>
           </Tabs>
         </main>
@@ -613,6 +619,55 @@ function OrdersTab() {
               <tr>
                 <td colSpan={6} className="p-6 text-center text-muted-foreground">
                   Aún no hay órdenes.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  )
+}
+
+function ServiceRequestsTab() {
+  const [requests, setRequests] = useState<ServiceRequest[]>([])
+
+  useEffect(() => {
+    listServiceRequests().then(setRequests).catch(() => setRequests([]))
+  }, [])
+
+  return (
+    <section className="grid gap-4">
+      <div className="flex items-center justify-between">
+        <div className="text-sm text-muted-foreground">{requests.length} solicitudes</div>
+      </div>
+      <div className="overflow-auto border rounded-md">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/50 text-muted-foreground">
+            <tr className="text-left">
+              <th className="p-3">Fecha</th>
+              <th className="p-3">Nombre</th>
+              <th className="p-3">Correo</th>
+              <th className="p-3">Servicio</th>
+              <th className="p-3">Presupuesto</th>
+              <th className="p-3">Mensaje</th>
+            </tr>
+          </thead>
+          <tbody>
+            {requests.map((r) => (
+              <tr key={r.id} className="border-t align-top">
+                <td className="p-3">{new Date(r.created_at).toLocaleString()}</td>
+                <td className="p-3">{r.name}</td>
+                <td className="p-3"><a href={`mailto:${r.email}`}>{r.email}</a></td>
+                <td className="p-3">{r.service}</td>
+                <td className="p-3">{r.budget ? `$ ${r.budget}` : "—"}</td>
+                <td className="p-3 max-w-[200px] break-words">{r.message}</td>
+              </tr>
+            ))}
+            {requests.length === 0 && (
+              <tr>
+                <td colSpan={6} className="p-6 text-center text-muted-foreground">
+                  Aún no hay solicitudes.
                 </td>
               </tr>
             )}

--- a/app/collection/page.tsx
+++ b/app/collection/page.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image"
 import Link from "next/link"
+import { useEffect, useState } from "react"
 import SiteHeader from "@/components/site-header"
 import SiteFooter from "@/components/site-footer"
 import CategorySpotlight from "@/components/category-spotlight"
@@ -10,8 +11,9 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import ProductCard from "@/components/product-card"
 import { CartProvider } from "@/components/cart"
 import { categories } from "@/lib/categories"
-import { products } from "@/lib/data"
 import HomeCollection from "@/components/home-collection"
+import { listProducts } from "@/hooks/supabase/products.supabase"
+import type { Products } from "@/interface/product.interface"
 
 const TABS = [
   { key: "all", label: "Todo" },
@@ -24,6 +26,11 @@ const TABS = [
 
 export default function CollectionPage() {
   const topCats = categories.slice(0, 3)
+  const [products, setProducts] = useState<Products[]>([])
+
+  useEffect(() => {
+    listProducts().then(setProducts).catch(() => setProducts([]))
+  }, [])
 
   const tiles = [
     { type: "link", src: "/images/categories/camisas.png", alt: "Camisas", href: "/categories/camisas", label: "Camisas", kicker: "Capítulo" },
@@ -93,7 +100,19 @@ export default function CollectionPage() {
                 </TabsList>
 
                 {TABS.map((t) => {
-                  const list = t.key === "all" ? products : products.filter((p) => (p.product.tags ?? []).includes(t.key))
+                  const list =
+                    t.key === "all"
+                      ? products
+                      : products.filter(
+                          (p) =>
+                            p.category?.name?.toLowerCase() === t.key ||
+                            p.type?.toLowerCase() === t.key ||
+                            p.product.some((v) =>
+                              (v.tags || [])
+                                .map((tag) => tag.toLowerCase())
+                                .includes(t.key),
+                            ),
+                        )
                   return (
                     <TabsContent key={t.key} value={t.key} className="mt-6">
                       <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">

--- a/hooks/supabase/services.supabase.ts
+++ b/hooks/supabase/services.supabase.ts
@@ -13,6 +13,16 @@ export interface ServiceRequestInput {
   message?: string
 }
 
+export interface ServiceRequest {
+  id: string
+  created_at: string
+  name: string
+  email: string
+  service: string
+  budget?: number | null
+  message?: string | null
+}
+
 export async function createServiceRequest(input: ServiceRequestInput) {
   const { data, error } = await supabase
     .from("service_requests")
@@ -27,4 +37,13 @@ export async function createServiceRequest(input: ServiceRequestInput) {
     .single()
   if (error) throw error
   return data
+}
+
+export async function listServiceRequests(): Promise<ServiceRequest[]> {
+  const { data, error } = await supabase
+    .from("service_requests")
+    .select("id, created_at, name, email, service, budget, message")
+    .order("created_at", { ascending: false })
+  if (error) throw error
+  return data || []
 }


### PR DESCRIPTION
## Summary
- display service requests in admin panel
- load featured collection products from Supabase
- expose Supabase hook to list service requests

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Next.js ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_b_68aa0f8b541c832eb5597b93b60444dc