### PR TITLE
Add loading skeletons for database-driven components

### DIFF
--- a/app/categories/[category]/page.tsx
+++ b/app/categories/[category]/page.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState, useEffect, use } from "react"
 import SiteHeader from "@/components/site-header"
 import SiteFooter from "@/components/site-footer"
 import ProductCard from "@/components/product-card"
+import ProductSkeleton from "@/components/product-skeleton"
 import Breadcrumbs from "@/components/breadcrumbs"
 import { useSearchParams, usePathname } from "next/navigation"
 import { CartProvider } from "@/components/cart"
@@ -35,8 +36,10 @@ export default function CategoryDetailPage({ params }: CategoryDetailPageProps) 
   const visibility = useMemo(() => getVisibilityMap(), [])
 
   const [baseItemsRaw, setBaseItemsRaw] = useState<Products[]>([])
+  const [loading, setLoading] = useState(true)
   const load = async () => {
     try {
+      setLoading(true)
       const allowedTypes = [
         "t-shirt",
         "hoodie",
@@ -63,6 +66,8 @@ export default function CategoryDetailPage({ params }: CategoryDetailPageProps) 
       console.error("Error loading products:", err)
       // Mostrar mensaje de error al usuario si es necesario
       setBaseItemsRaw([])
+    } finally {
+      setLoading(false)
     }
   }
 
@@ -319,7 +324,11 @@ export default function CategoryDetailPage({ params }: CategoryDetailPageProps) 
                 </div>
               )}
 
-              {filteredItems.length === 0 ? (
+              {loading ? (
+                <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
+                  <ProductSkeleton count={12} />
+                </div>
+              ) : filteredItems.length === 0 ? (
                 <div className="flex flex-col items-center justify-center py-12 space-y-4">
                   <svg className="w-16 h-16 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />

--- a/app/collection/page.tsx
+++ b/app/collection/page.tsx
@@ -14,6 +14,7 @@ import { categories } from "@/lib/categories"
 import HomeCollection from "@/components/home-collection"
 import { listProducts } from "@/hooks/supabase/products.supabase"
 import type { Products } from "@/interface/product.interface"
+import ProductSkeleton from "@/components/product-skeleton"
 
 const TABS = [
   { key: "all", label: "Todo" },
@@ -27,9 +28,20 @@ const TABS = [
 export default function CollectionPage() {
   const topCats = categories.slice(0, 8)
   const [products, setProducts] = useState<Products[]>([])
+  const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    listProducts().then(setProducts).catch(() => setProducts([]))
+    const load = async () => {
+      try {
+        const data = await listProducts()
+        setProducts(data)
+      } catch {
+        setProducts([])
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
   }, [])
 
   const tiles = [
@@ -115,14 +127,20 @@ export default function CollectionPage() {
                       )
                   return (
                     <TabsContent key={t.key} value={t.key} className="mt-6">
-                      <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
-                        {list.map((p) => (
-                          <ProductCard key={p.id} product={p} />
-                        ))}
-                        {list.length === 0 && (
-                          <p className="text-sm text-muted-foreground">No hay piezas en esta categoría por ahora.</p>
-                        )}
-                      </div>
+                      {loading ? (
+                        <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
+                          <ProductSkeleton count={4} />
+                        </div>
+                      ) : (
+                        <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
+                          {list.map((p) => (
+                            <ProductCard key={p.id} product={p} />
+                          ))}
+                          {list.length === 0 && (
+                            <p className="text-sm text-muted-foreground">No hay piezas en esta categoría por ahora.</p>
+                          )}
+                        </div>
+                      )}
                     </TabsContent>
                   )
                 })}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,20 +18,24 @@ import CategorySpotlight from "@/components/category-spotlight"
 import HomeCollection from "@/components/home-collection"
 import AudienceSections from "@/components/audience-sections"
 import BackToTop from "@/components/back-to-top"
-import React, { useEffect } from 'react'; 
+import React, { useEffect } from 'react';
 import { getLatestProducts } from "@/hooks/supabase/products.supabase"
+import ProductSkeleton from "@/components/product-skeleton"
 
 export default function Page() {
   const featuredCats = categories
-  const [latestProducts, setLatestProducts] = React.useState<any[]>([]);
+  const [latestProducts, setLatestProducts] = React.useState<any[]>([])
+  const [loading, setLoading] = React.useState(true)
 
   useEffect(() => {
     async function fetchProducts() {
-      const products = await getLatestProducts();
-      setLatestProducts(products);
+      setLoading(true)
+      const products = await getLatestProducts()
+      setLatestProducts(products)
+      setLoading(false)
     }
-    fetchProducts();
-  }, []);
+    fetchProducts()
+  }, [])
   return (
     <CartProvider>
       <div className="flex min-h-[100dvh] flex-col bg-white">
@@ -88,9 +92,13 @@ export default function Page() {
               </Link>
             </div>
             <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
-              {latestProducts.slice(0, 4).map((p) => (
-                <ProductCard key={p.id} product={p} />
-              ))}
+              {loading ? (
+                <ProductSkeleton count={4} />
+              ) : (
+                latestProducts.slice(0, 4).map((p) => (
+                  <ProductCard key={p.id} product={p} />
+                ))
+              )}
             </div>
           </section>
 

--- a/app/product/[id]/page.tsx
+++ b/app/product/[id]/page.tsx
@@ -10,6 +10,7 @@ import ProductCard from "@/components/product-card"
 import { getProductById, listProducts } from "@/hooks/supabase/products.supabase"
 import { Products } from "@/interface/product.interface"
 import { CartProvider } from "@/components/cart"
+import ProductPageSkeleton from "@/components/product-page-skeleton"
 
 type PageProps = {
   params: { id?: string }
@@ -40,8 +41,20 @@ export default function ProductPage({ params }: PageProps) {
     if (id) load()
   }, [id])
 
-  if (!loading && !product) return notFound()
-  if (!product) return null
+  if (loading) {
+    return (
+      <CartProvider>
+        <div className="flex min-h-[100dvh] flex-col">
+          <SiteHeader />
+          <main className="container mx-auto px-4 py-10 grid gap-10 lg:grid-cols-2">
+            <ProductPageSkeleton />
+          </main>
+          <SiteFooter />
+        </div>
+      </CartProvider>
+    )
+  }
+  if (!product) return notFound()
 
   const selectedVariant = product.product.find(v => v.color === selectedColor) ?? product.product[0]
 

--- a/app/wishlist/page.tsx
+++ b/app/wishlist/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react"
 import SiteHeader from "@/components/site-header"
 import SiteFooter from "@/components/site-footer"
 import ProductCard from "@/components/product-card"
+import ProductSkeleton from "@/components/product-skeleton"
 import { CartProvider } from "@/components/cart"
 import { useWishlist } from "@/components/wishlist"
 import { getProductsByIds } from "@/hooks/supabase/products.supabase"
@@ -12,19 +13,24 @@ import { Products } from "@/interface/product.interface"
 export default function WishlistPage() {
   const { slugs, clear } = useWishlist()
   const [products, setProducts] = useState<Products[]>([])
+  const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     const load = async () => {
       if (slugs.length === 0) {
         setProducts([])
+        setLoading(false)
         return
       }
       try {
+        setLoading(true)
         const fetched = await getProductsByIds(slugs)
         setProducts(fetched)
       } catch (err) {
         console.error(err)
         setProducts([])
+      } finally {
+        setLoading(false)
       }
     }
     load()
@@ -49,6 +55,10 @@ export default function WishlistPage() {
 
           {slugs.length === 0 ? (
             <p className="text-sm text-muted-foreground">Aún no has agregado productos a tu lista de deseos.</p>
+          ) : loading ? (
+            <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
+              <ProductSkeleton count={Math.min(slugs.length, 4) || 4} />
+            </div>
           ) : (
             <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
               {products.map((p) => (

--- a/components/audience-sections.tsx
+++ b/components/audience-sections.tsx
@@ -3,6 +3,8 @@
 import Image from "next/image"
 import Link from "next/link"
 import ProductCard from "@/components/product-card"
+import ProductSkeleton from "@/components/product-skeleton"
+import { Skeleton } from "@/components/ui/skeleton"
 import { ProductTag, Products } from "@/interface/product.interface"
 import { hasAudienceTag, listProducts } from "@/hooks/supabase/products.supabase"
 import { useEffect, useState } from "react"
@@ -52,7 +54,23 @@ export default function AudienceSections() {
     return (
       <section aria-label="Por audiencia" className="bg-white">
         <div className="container mx-auto px-4 py-12 grid gap-8">
-          <div className="text-center py-12">Cargando productos...</div>
+          <header className="flex items-end justify-between">
+            <div className="grid gap-1">
+              <Skeleton className="h-6 w-48" />
+              <Skeleton className="h-4 w-64" />
+            </div>
+            <Skeleton className="h-4 w-32" />
+          </header>
+          <div className="grid gap-8">
+            {AUDIENCES.map((a) => (
+              <div key={a.key} className="grid lg:grid-cols-2 gap-6 items-start">
+                <Skeleton className="relative aspect-[16/9] w-full rounded-md" />
+                <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-6">
+                  <ProductSkeleton count={3} />
+                </div>
+              </div>
+            ))}
+          </div>
         </div>
       </section>
     )

--- a/components/product-page-skeleton.tsx
+++ b/components/product-page-skeleton.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import ProductSkeleton from "@/components/product-skeleton"
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function ProductPageSkeleton() {
+  return (
+    <>
+      <div className="grid gap-4">
+        <Skeleton className="aspect-[4/5] w-full rounded-md" />
+        <div className="grid grid-cols-4 gap-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="aspect-square w-full rounded-md" />
+          ))}
+        </div>
+      </div>
+      <div className="lg:pl-6 grid gap-4">
+        <Skeleton className="h-8 w-3/4" />
+        <Skeleton className="h-4 w-1/2" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-10 w-32" />
+      </div>
+      <div className="lg:col-span-2 mt-6 border-t pt-8">
+        <Skeleton className="h-6 w-48 mb-6" />
+        <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
+          <ProductSkeleton count={4} />
+        </div>
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- show skeleton placeholders in audience, collection, category, wishlist, product, and home pages while database content loads
- add shared `ProductPageSkeleton` for product detail view

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68aa26b77c8c832eb1a2686a26977336