### PR TITLE
feat: animate page transitions

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { GeistSans } from 'geist/font/sans'
 import { GeistMono } from 'geist/font/mono'
 import './globals.css'
+import PageTransition from '@/components/page-transition'
 
 export const metadata: Metadata = {
   title: 'Inkspire Studio',
@@ -27,7 +28,9 @@ html {
 }
         `}</style>
       </head>
-      <body>{children}</body>
+      <body>
+        <PageTransition>{children}</PageTransition>
+      </body>
     </html>
   )
 }

--- a/components/page-transition.tsx
+++ b/components/page-transition.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import { usePathname } from "next/navigation"
+
+export default function PageTransition({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname()
+  return (
+    <div key={pathname} className="opacity-0 animate-in fade-in duration-300 ease-out">
+      {children}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add fade-in animation wrapper for all pages
- initialize PageTransition component using route key

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(interactive prompt, lint not executed)*
- `npm run build` *(build started but was interrupted)*

------
https://chatgpt.com/codex/tasks/task_b_68aa2e0e0070832e8312811cb979aa8b