### PR TITLE
Add SEO, sitemap, and PWA support

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -33,6 +33,7 @@ import { ServiceRequest, listServiceRequests } from "@/hooks/supabase/services.s
 import { CartProvider } from "@/components/cart"
 import { Products, ProductTag } from "@/interface/product.interface"
 import { useAuthStore } from "@/store/authStore"
+import SEO from "@/components/seo"
 
 const TAG_OPTIONS: ProductTag[] = ["women", "men", "kids"]
 
@@ -41,6 +42,7 @@ export default function AdminPage() {
 
   return (
     <CartProvider>
+      <SEO title="Admin" description="Panel de administración de Inkspire Studio." />
       <div className="flex min-h-[100dvh] flex-col bg-white">
         <SiteHeader />
         <main className="container mx-auto px-4 py-10 grid gap-8">

--- a/app/categories/[category]/page.tsx
+++ b/app/categories/[category]/page.tsx
@@ -17,6 +17,7 @@ import { getVisibilityMap } from "@/lib/admin-store"
 import { getProductsByCategoryName } from "@/hooks/supabase/categories.supabase"
 import { getProductsByType } from "@/hooks/supabase/products.supabase"
 import { Products } from "@/interface/product.interface"
+import SEO from "@/components/seo"
 
 interface CategoryDetailPageProps {
   params: Promise<{ category: string }>;
@@ -193,6 +194,7 @@ export default function CategoryDetailPage({ params }: CategoryDetailPageProps) 
 
   return (
     <CartProvider>
+      <SEO title={`Categoría: ${cleanTextCat}`} description={`Productos de ${cleanTextCat} en Inkspire Studio.`} />
       <div className="flex min-h-[100dvh] flex-col">
         <SiteHeader />
         <main className="container mx-auto px-4 pt-8 pb-10 grid gap-5">

--- a/app/categories/page.tsx
+++ b/app/categories/page.tsx
@@ -7,6 +7,7 @@ import { CartProvider } from "@/components/cart"
 import { listCategoriesWithProductCount } from "@/hooks/supabase/categories.supabase"
 import { useEffect, useState } from "react"
 import { Skeleton } from "@/components/ui/skeleton" // Asegúrate de tener este componente
+import SEO from "@/components/seo"
 
 export default function CategoriesPage() {
   const [categories, setCategories] = useState<any[]>([])
@@ -31,6 +32,7 @@ export default function CategoriesPage() {
 
   return (
     <CartProvider>
+      <SEO title="Categorías" description="Explora por temas y tipos de producto." />
       <div className="flex min-h-[100dvh] flex-col">
         <SiteHeader />
         <main className="container mx-auto px-4 py-10 grid gap-8">

--- a/app/collection/page.tsx
+++ b/app/collection/page.tsx
@@ -15,6 +15,7 @@ import HomeCollection from "@/components/home-collection"
 import { listProducts } from "@/hooks/supabase/products.supabase"
 import type { Products } from "@/interface/product.interface"
 import ProductSkeleton from "@/components/product-skeleton"
+import SEO from "@/components/seo"
 
 const TABS = [
   { key: "all", label: "Todo" },
@@ -57,6 +58,7 @@ export default function CollectionPage() {
 
   return (
     <CartProvider>
+      <SEO title="Colección" description="Descubre nuestra colección destacada de prendas." />
       <div className="flex max-h-[50dvh] flex-col bg-white">
         <SiteHeader />
         <main className="flex-1">

--- a/app/customize/page.tsx
+++ b/app/customize/page.tsx
@@ -13,6 +13,7 @@ import { Upload, Move, RotateCw, ZoomIn, Trash2, Plus } from 'lucide-react'
 import { CartProvider } from "@/components/cart"
 import { Slider } from "@/components/ui/slider"
 import TShirtViewer2D from "@/components/tshirt-viewer"
+import SEO from "@/components/seo"
 
 type Garment = "Camisa" | "Hoodie"
 type Placement = {
@@ -101,6 +102,7 @@ const getSideImagesByColor = (color: string): Record<string, string> => {
 export default function CustomizePage() {
   return (
     <CartProvider>
+      <SEO title="Personaliza" description="Diseña tus propias prendas personalizadas." />
       <div className="flex min-h-[100dvh] flex-col">
         <SiteHeader />
         <main className="container mx-auto px-4 py-10 grid gap-8 lg:grid-cols-2">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { GeistSans } from 'geist/font/sans'
 import { GeistMono } from 'geist/font/mono'
 import './globals.css'
 import PageTransition from '@/components/page-transition'
+import ServiceWorkerRegister from '@/components/service-worker-register'
 
 export const metadata: Metadata = {
   title: 'Inkspire Studio',
@@ -20,6 +21,8 @@ export default function RootLayout({
       <head>
         <link rel="icon" type="image/x-icon" href="/logo.png" />
         <link rel="stylesheet" href="icon" />
+        <link rel="manifest" href="/manifest.json" />
+        <meta name="theme-color" content="#000000" />
         <style>{`
 html {
   font-family: ${GeistSans.style.fontFamily};
@@ -29,6 +32,7 @@ html {
         `}</style>
       </head>
       <body>
+        <ServiceWorkerRegister />
         <PageTransition>{children}</PageTransition>
       </body>
     </html>

--- a/app/orders/page.tsx
+++ b/app/orders/page.tsx
@@ -7,6 +7,7 @@ import { CartProvider } from "@/components/cart"
 import { getOrdersByEmail, Order } from "@/hooks/supabase/orders.supabase"
 import { formatCurrency } from "@/lib/format"
 import { useAuthStore } from "@/store/authStore"
+import SEO from "@/components/seo"
 
 export default function OrdersPage() {
   const { user } = useAuthStore()
@@ -28,6 +29,7 @@ export default function OrdersPage() {
 
   return (
     <CartProvider>
+      <SEO title="Órdenes" description="Revisa el estado de tus pedidos." />
       <div className="flex min-h-[100dvh] flex-col bg-white">
         <SiteHeader />
         <main className="container mx-auto px-4 py-10 grid gap-6">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,6 +20,7 @@ import BackToTop from "@/components/back-to-top"
 import React, { useEffect } from 'react';
 import { getLatestProducts } from "@/hooks/supabase/products.supabase"
 import ProductSkeleton from "@/components/product-skeleton"
+import SEO from "@/components/seo"
 
 export default function Page() {
   const featuredCats = categories
@@ -37,6 +38,7 @@ export default function Page() {
   }, [])
   return (
     <CartProvider>
+      <SEO title="Inicio" description="Camisas y hoodies personalizados con calidad de estudio." />
       <div className="flex min-h-[100dvh] flex-col bg-white">
         <SiteHeader />
         <main className="flex-1">

--- a/app/product/[id]/page.tsx
+++ b/app/product/[id]/page.tsx
@@ -11,6 +11,7 @@ import { getProductById, listProducts } from "@/hooks/supabase/products.supabase
 import { Products } from "@/interface/product.interface"
 import { CartProvider } from "@/components/cart"
 import ProductPageSkeleton from "@/components/product-page-skeleton"
+import SEO from "@/components/seo"
 
 export default function ProductPage() {
   const params = useParams<{ id: string | string[] }>()
@@ -42,6 +43,7 @@ export default function ProductPage() {
   if (loading) {
     return (
       <CartProvider>
+        <SEO title="Producto" description="Cargando producto..." />
         <div className="flex min-h-[100dvh] flex-col">
           <SiteHeader />
           <main className="container mx-auto px-4 py-10 grid gap-10 lg:grid-cols-2">
@@ -58,6 +60,7 @@ export default function ProductPage() {
     // redirect("/404") // <- si prefieres redirigir
     return (
       <CartProvider>
+        <SEO title="Producto no encontrado" description="Producto no encontrado" />
         <div className="flex min-h-[100dvh] flex-col">
           <SiteHeader />
           <main className="container mx-auto px-4 py-10">
@@ -74,6 +77,7 @@ export default function ProductPage() {
 
   return (
     <CartProvider>
+      <SEO title={product.title} description={product.description} />
       <div className="flex min-h-[100dvh] flex-col">
         <SiteHeader />
         <main className="container mx-auto px-4 py-10 grid gap-10 lg:grid-cols-2">

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -15,6 +15,7 @@ import { Button } from "@/components/ui/button"
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet"
 import { useIntersection } from "@/hooks/use-intersection"
 import { cn } from "@/lib/utils"
+import SEO from "@/components/seo"
 
 type SortKey = "relevance" | "price-asc" | "price-desc" | "title-asc" | "title-desc"
 
@@ -105,6 +106,7 @@ export default function ProductsPage() {
 
   return (
     <CartProvider>
+      <SEO title="Productos" description="Explora todos nuestros productos personalizados." />
       <div className="flex min-h-[100dvh] flex-col bg-white">
         <SiteHeader />
 

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -9,10 +9,12 @@ import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import { requestDesign } from "./actions"
 import { CartProvider } from "@/components/cart"
+import SEO from "@/components/seo"
 
 export default function ServicesPage() {
   return (
     <CartProvider>
+      <SEO title="Servicios de diseño" description="Branding, ilustración y diseños a medida." />
       <div className="flex min-h-[100dvh] flex-col">
         <SiteHeader />
         <main className="container mx-auto px-4 py-10 grid gap-8 md:max-w-3xl">

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,32 @@
+import { MetadataRoute } from 'next'
+import { listProducts } from '@/hooks/supabase/products.supabase'
+import { categories } from '@/lib/categories'
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://inkspire-studio.com'
+
+  const staticRoutes = ['', '/products', '/categories', '/collection', '/customize', '/services', '/wishlist', '/admin', '/orders'].map((route) => ({
+    url: `${baseUrl}${route}`,
+    lastModified: new Date(),
+  }))
+
+  const productRoutes: MetadataRoute.Sitemap = []
+  try {
+    const products = await listProducts()
+    productRoutes.push(
+      ...products.map((p) => ({
+        url: `${baseUrl}/product/${p.id}`,
+        lastModified: new Date(),
+      }))
+    )
+  } catch (e) {
+    console.error('Error fetching products for sitemap', e)
+  }
+
+  const categoryRoutes: MetadataRoute.Sitemap = categories.map((c) => ({
+    url: `${baseUrl}/categories/${c.slug}`,
+    lastModified: new Date(),
+  }))
+
+  return [...staticRoutes, ...productRoutes, ...categoryRoutes]
+}

--- a/app/wishlist/page.tsx
+++ b/app/wishlist/page.tsx
@@ -9,6 +9,7 @@ import { CartProvider } from "@/components/cart"
 import { useWishlist } from "@/components/wishlist"
 import { getProductsByIds } from "@/hooks/supabase/products.supabase"
 import { Products } from "@/interface/product.interface"
+import SEO from "@/components/seo"
 
 export default function WishlistPage() {
   const { slugs, clear } = useWishlist()
@@ -38,6 +39,7 @@ export default function WishlistPage() {
 
   return (
     <CartProvider>
+      <SEO title="Wishlist" description="Tu lista de deseos de Inkspire Studio." />
       <div className="flex min-h-[100dvh] flex-col bg-white">
         <SiteHeader />
         <main className="container mx-auto px-4 py-10 grid gap-6">

--- a/components/seo.tsx
+++ b/components/seo.tsx
@@ -1,0 +1,28 @@
+import Head from 'next/head'
+
+interface SEOProps {
+  title: string
+  description?: string
+  url?: string
+  image?: string
+}
+
+export default function SEO({ title, description, url, image }: SEOProps) {
+  const siteUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://inkspire-studio.com'
+  const pageUrl = url ? `${siteUrl}${url}` : siteUrl
+  const metaTitle = `${title} | Inkspire Studio`
+  const metaDescription = description || 'Inkspire Studio - Personalización premium en prendas.'
+  const metaImage = image || `${siteUrl}/logo.png`
+
+  return (
+    <Head>
+      <title>{metaTitle}</title>
+      <meta name="description" content={metaDescription} />
+      <meta property="og:title" content={metaTitle} />
+      <meta property="og:description" content={metaDescription} />
+      <meta property="og:image" content={metaImage} />
+      <meta property="og:url" content={pageUrl} />
+      <link rel="canonical" href={pageUrl} />
+    </Head>
+  )
+}

--- a/components/service-worker-register.tsx
+++ b/components/service-worker-register.tsx
@@ -1,0 +1,14 @@
+"use client"
+
+import { useEffect } from 'react'
+
+export default function ServiceWorkerRegister() {
+  useEffect(() => {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker
+        .register('/sw.js')
+        .catch(err => console.error('SW registration failed', err))
+    }
+  }, [])
+  return null
+}

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "Inkspire Studio",
+  "short_name": "Inkspire",
+  "description": "Personaliza camisas y hoodies con Inkspire Studio.",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#000000",
+  "icons": [
+    {
+      "src": "/logo.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/logo.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,14 @@
+const CACHE = 'inkspire-cache-v1'
+const OFFLINE_URLS = ['/']
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE).then(cache => cache.addAll(OFFLINE_URLS))
+  )
+})
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(resp => resp || fetch(event.request))
+  )
+})


### PR DESCRIPTION
## Summary
- add reusable SEO component and integrate across pages for per-route metadata
- generate dynamic sitemap including products and categories
- enable PWA install with manifest, service worker, and registration

## Testing
- `npm run lint` *(fails: requires interactive ESLint setup)*
- `npm run build` *(terminated early while optimizing build)*

------
https://chatgpt.com/codex/tasks/task_b_68aa312dd5fc832eb5d714da2576ea76