### PR TITLE
feat: add supabase product search

### DIFF
--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,0 +1,38 @@
+import SiteHeader from "@/components/site-header";
+import SiteFooter from "@/components/site-footer";
+import ProductCard from "@/components/product-card";
+import { CartProvider } from "@/components/cart";
+import { searchProducts } from "@/hooks/supabase/search.supabase";
+
+interface SearchPageProps {
+  searchParams: { q?: string };
+}
+
+export default async function SearchPage({ searchParams }: SearchPageProps) {
+  const q = searchParams.q?.toString() ?? "";
+  const products = q ? await searchProducts(q) : [];
+
+  return (
+    <CartProvider>
+      <div className="flex min-h-[100dvh] flex-col">
+        <SiteHeader />
+        <main className="container mx-auto px-4 py-8 grid gap-6">
+          <h1 className="text-2xl md:text-3xl tracking-tight">
+            {q ? `Resultados para "${q}"` : "Buscar productos"}
+          </h1>
+          {q && products.length === 0 && (
+            <p className="text-muted-foreground">No se encontraron productos.</p>
+          )}
+          {products.length > 0 && (
+            <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+              {products.map((p) => (
+                <ProductCard key={p.id} product={p} />
+              ))}
+            </div>
+          )}
+        </main>
+        <SiteFooter />
+      </div>
+    </CartProvider>
+  );
+}

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link"
 import { useState } from "react"
+import { useRouter } from "next/navigation"
 import { ShoppingBag, Search, User } from 'lucide-react'
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -16,6 +17,8 @@ import { useWishlist } from "@/components/wishlist"
 export default function SiteHeader() {
   const { count, setOpen } = useCart()
   const [showSearch, setShowSearch] = useState(false)
+  const [searchQuery, setSearchQuery] = useState("")
+  const router = useRouter()
   const { openAuth } = useAuth()
   const user = useAuthStore((state) => state.user)
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
@@ -40,14 +43,26 @@ export default function SiteHeader() {
 
           <div className="flex items-center gap-2">
             <div className="hidden md:flex items-center">
-              <div className="relative">
+              <form
+                className="relative"
+                onSubmit={(e) => {
+                  e.preventDefault()
+                  if (searchQuery.trim()) {
+                    router.push(`/search?q=${encodeURIComponent(searchQuery.trim())}`)
+                    setShowSearch(false)
+                    setSearchQuery("")
+                  }
+                }}
+              >
                 <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
                 <Input
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
                   placeholder="Buscar productos"
                   className="pl-9 w-[220px] rounded-none"
                   aria-label="Buscar"
                 />
-              </div>
+              </form>
             </div>
 
             <Button
@@ -124,14 +139,26 @@ export default function SiteHeader() {
 
         {showSearch && (
           <div className="pb-3 md:hidden">
-            <div className="relative">
+            <form
+              className="relative"
+              onSubmit={(e) => {
+                e.preventDefault()
+                if (searchQuery.trim()) {
+                  router.push(`/search?q=${encodeURIComponent(searchQuery.trim())}`)
+                  setShowSearch(false)
+                  setSearchQuery("")
+                }
+              }}
+            >
               <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
               <Input
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
                 placeholder="Buscar productos"
                 className="pl-9 rounded-none"
                 aria-label="Buscar"
               />
-            </div>
+            </form>
           </div>
         )}
       </div>

--- a/hooks/supabase/search.supabase.ts
+++ b/hooks/supabase/search.supabase.ts
@@ -1,0 +1,47 @@
+import { Products } from "@/interface/product.interface";
+import { supabase } from "@/utils/supabase/server";
+
+/**
+ * Busca productos que coincidan con el término dado en el título, tipo o nombre de la categoría.
+ */
+export const searchProducts = async (query: string): Promise<Products[]> => {
+  const q = query.trim();
+  if (!q) return [];
+
+  const { data, error } = await supabase
+    .from("products")
+    .select(`
+      id,
+      title,
+      description,
+      type,
+      material,
+      price,
+      discount_percentage,
+      category:categories(name,image),
+      product_variants(color,sizes,images,tags)
+    `)
+    .or(`title.ilike.%${q}%,type.ilike.%${q}%,categories.name.ilike.%${q}%`);
+
+  if (error) throw error;
+
+  return (data || []).map((p: any) => ({
+    id: p.id,
+    title: p.title,
+    description: p.description,
+    type: p.type,
+    material: p.material,
+    price: p.price,
+    discountPercentage: p.discount_percentage,
+    category: {
+      name: p.category?.name,
+      image: p.category?.image,
+    },
+    product: (p.product_variants || []).map((v: any) => ({
+      color: v.color,
+      size: v.sizes || [],
+      images: v.images || [],
+      tags: v.tags || [],
+    })),
+  }));
+};


### PR DESCRIPTION
## Summary
- add Supabase helper for product search across title, type and category
- integrate search bar with routing to new search results page
- display search results using ProductCard components

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(prompts for ESLint setup)*
- `npm run build` *(interrupted after starting build)*

------
https://chatgpt.com/codex/tasks/task_b_68aa842d642c832e81cef40d1de4768e