### PR TITLE
feat: improve search and category refresh

### DIFF
--- a/app/categories/category-page.tsx
+++ b/app/categories/category-page.tsx
@@ -31,8 +31,7 @@ export default function CategoriesPageClient({ initialCategories }: CategoriesPa
         setLoading(false)
       }
     }
-    
-    // refreshCategories() // Descomenta si quieres siempre datos frescos
+    refreshCategories()
   }, [])
 
   return (

--- a/app/categories/page.tsx
+++ b/app/categories/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from 'next'
 import { listCategoriesWithProductCount } from "@/hooks/supabase/categories.supabase"
 import CategoriesPageClient from './category-page'
 
+export const revalidate = 0
+
 export async function generateMetadata(): Promise<Metadata> {
   // Obtener categorías para metadata dinámica
   const categories = await listCategoriesWithProductCount()

--- a/hooks/supabase/search.supabase.ts
+++ b/hooks/supabase/search.supabase.ts
@@ -21,7 +21,9 @@ export const searchProducts = async (query: string): Promise<Products[]> => {
       category:categories(name,image),
       product_variants(color,sizes,images,tags)
     `)
-    .or(`title.ilike.%${q}%,type.ilike.%${q}%,categories.name.ilike.%${q}%`);
+    .or(
+      `title.ilike.%${q}%,type.ilike.%${q}%,category.name.ilike.%${q}%`
+    );
 
   if (error) throw error;
 


### PR DESCRIPTION
## Summary
- expand Supabase search hook to match by title, type, and category
- refresh categories dynamically and disable caching for category listings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68aa8a14c754832eab4fd6407b6c06ae