### PR TITLE
feat: add supabase search suggestions

### DIFF
--- a/app/categories/category-page.tsx
+++ b/app/categories/category-page.tsx
@@ -7,19 +7,23 @@ import { CartProvider } from "@/components/cart"
 import { listCategoriesWithProductCount } from "@/hooks/supabase/categories.supabase"
 import { useEffect, useState } from "react"
 import { Skeleton } from "@/components/ui/skeleton"
+import ProductCard from "@/components/product-card"
+import type { Products } from "@/interface/product.interface"
 
 interface CategoriesPageClientProps {
   initialCategories: any[]
+  initialProducts?: Products[]
+  searchQuery?: string
 }
 
-export default function CategoriesPageClient({ initialCategories }: CategoriesPageClientProps) {
+export default function CategoriesPageClient({ initialCategories, initialProducts = [], searchQuery = "" }: CategoriesPageClientProps) {
   const [categories, setCategories] = useState<any[]>(initialCategories)
   const [loading, setLoading] = useState(false)
+  const [products] = useState<Products[]>(initialProducts)
 
-  // Si necesitas recargar categorías después de la carga inicial
+  // Refrescar categorías solo si no hay búsqueda
   useEffect(() => {
-    // Puedes agregar lógica para recargar categorías si es necesario
-    // Por ejemplo, si quieres datos siempre frescos
+    if (searchQuery) return
     const refreshCategories = async () => {
       try {
         setLoading(true)
@@ -32,40 +36,57 @@ export default function CategoriesPageClient({ initialCategories }: CategoriesPa
       }
     }
     refreshCategories()
-  }, [])
+  }, [searchQuery])
 
   return (
     <CartProvider>
       <div className="flex min-h-[100dvh] flex-col">
         <SiteHeader />
         <main className="container mx-auto px-4 py-10 grid gap-8">
-          <header className="grid gap-2">
-            <h1 className="text-2xl md:text-3xl tracking-tight">Categorías</h1>
-            <p className="text-sm text-muted-foreground">Explora por temas y tipos de producto.</p>
-          </header>
-
-          {loading ? (
-            <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
-              {/* Esqueletos de carga */}
-              {[...Array(6)].map((_, index) => (
-                <div key={index} className="space-y-4">
-                  <Skeleton className="h-48 w-full rounded-lg" />
-                  <Skeleton className="h-6 w-3/4" />
-                  <Skeleton className="h-4 w-1/2" />
-                </div>
-              ))}
-            </div>
+          {searchQuery ? (
+            <>
+              <header className="grid gap-2">
+                <h1 className="text-2xl md:text-3xl tracking-tight">Resultados para "{searchQuery}"</h1>
+              </header>
+              {products.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No se encontraron productos.</p>
+              ) : (
+                <section className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                  {products.map((p) => (
+                    <ProductCard key={p.id} product={p} />
+                  ))}
+                </section>
+              )}
+            </>
           ) : (
-            <section className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
-              {categories.map((cat) => (
-                <CategoryCard
-                  key={cat.name}
-                  name={cat.name}
-                  image={cat.image}
-                  count={cat.count} // Asegúrate que este campo coincida con tu respuesta
-                />
-              ))}
-            </section>
+            <>
+              <header className="grid gap-2">
+                <h1 className="text-2xl md:text-3xl tracking-tight">Categorías</h1>
+                <p className="text-sm text-muted-foreground">Explora por temas y tipos de producto.</p>
+              </header>
+              {loading ? (
+                <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                  {[...Array(6)].map((_, index) => (
+                    <div key={index} className="space-y-4">
+                      <Skeleton className="h-48 w-full rounded-lg" />
+                      <Skeleton className="h-6 w-3/4" />
+                      <Skeleton className="h-4 w-1/2" />
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <section className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                  {categories.map((cat) => (
+                    <CategoryCard
+                      key={cat.name}
+                      name={cat.name}
+                      image={cat.image}
+                      count={cat.count}
+                    />
+                  ))}
+                </section>
+              )}
+            </>
           )}
         </main>
         <SiteFooter />

--- a/app/categories/page.tsx
+++ b/app/categories/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { listCategoriesWithProductCount } from "@/hooks/supabase/categories.supabase"
 import CategoriesPageClient from './category-page'
+import { searchProducts } from "@/hooks/supabase/search.supabase"
 
 export const revalidate = 0
 
@@ -31,9 +32,22 @@ export async function generateMetadata(): Promise<Metadata> {
   }
 }
 
-export default async function CategoriesPage() {
-  // Obtener datos en el servidor
+interface PageProps {
+  searchParams: { q?: string }
+}
+
+export default async function CategoriesPage({ searchParams }: PageProps) {
+  const q = searchParams.q?.toString() ?? ""
+  if (q) {
+    const products = await searchProducts(q)
+    return (
+      <CategoriesPageClient
+        initialCategories={[]}
+        initialProducts={products}
+        searchQuery={q}
+      />
+    )
+  }
   const categories = await listCategoriesWithProductCount()
-  
-  return <CategoriesPageClient initialCategories={categories} />
+  return <CategoriesPageClient initialCategories={categories} initialProducts={[]} searchQuery="" />
 }


### PR DESCRIPTION
## Summary
- query Supabase for products from the search bar and show dropdown suggestions
- route search submissions to the categories page
- allow categories page to render search results across titles and categories

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Missing NEXT_PUBLIC_SUPABASE_SERVICE_ROLE_KEY environment variable)*

------
https://chatgpt.com/codex/tasks/task_b_68aa8dc14884832e902ae5405a055247